### PR TITLE
Fix auxiliary decay files for long lived chargino

### DIFF
--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+03   # n1
    1000024   1.000325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+03   # n1
    1000024   1.000183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1000_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+03   # n1
    1000024   1.000236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+02   # n1
    1000024   1.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+02   # n1
    1000024   1.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-100_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+02   # n1
    1000024   1.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.015000e+03   # n1
    1000024   1.015325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.015000e+03   # n1
    1000024   1.015183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1015_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.015000e+03   # n1
    1000024   1.015236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.025000e+03   # n1
    1000024   1.025325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.025000e+03   # n1
    1000024   1.025183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1025_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.025000e+03   # n1
    1000024   1.025236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.050000e+03   # n1
    1000024   1.050325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.050000e+03   # n1
    1000024   1.050183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1050_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.050000e+03   # n1
    1000024   1.050236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.065000e+03   # n1
    1000024   1.065325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.065000e+03   # n1
    1000024   1.065183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1065_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.065000e+03   # n1
    1000024   1.065236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.075000e+03   # n1
    1000024   1.075325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.075000e+03   # n1
    1000024   1.075183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1075_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.075000e+03   # n1
    1000024   1.075236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.100000e+03   # n1
    1000024   1.100325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.100000e+03   # n1
    1000024   1.100183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1100_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.100000e+03   # n1
    1000024   1.100236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.115000e+03   # n1
    1000024   1.115325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.115000e+03   # n1
    1000024   1.115183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1115_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.115000e+03   # n1
    1000024   1.115236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.125000e+03   # n1
    1000024   1.125325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.125000e+03   # n1
    1000024   1.125183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1125_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.125000e+03   # n1
    1000024   1.125236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.150000e+03   # n1
    1000024   1.150325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.150000e+03   # n1
    1000024   1.150183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1150_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.150000e+03   # n1
    1000024   1.150236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.165000e+03   # n1
    1000024   1.165325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.165000e+03   # n1
    1000024   1.165183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1165_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.165000e+03   # n1
    1000024   1.165236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.175000e+03   # n1
    1000024   1.175325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.175000e+03   # n1
    1000024   1.175183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1175_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.175000e+03   # n1
    1000024   1.175236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.200000e+03   # n1
    1000024   1.200325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.200000e+03   # n1
    1000024   1.200183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1200_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.200000e+03   # n1
    1000024   1.200236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.215000e+03   # n1
    1000024   1.215325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.215000e+03   # n1
    1000024   1.215183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1215_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.215000e+03   # n1
    1000024   1.215236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.225000e+03   # n1
    1000024   1.225325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.225000e+03   # n1
    1000024   1.225183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1225_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.225000e+03   # n1
    1000024   1.225236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+03   # n1
    1000024   1.250325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+03   # n1
    1000024   1.250183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1250_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+03   # n1
    1000024   1.250236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+02   # n1
    1000024   1.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+02   # n1
    1000024   1.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-125_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.250000e+02   # n1
    1000024   1.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.265000e+03   # n1
    1000024   1.265325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.265000e+03   # n1
    1000024   1.265183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1265_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.265000e+03   # n1
    1000024   1.265236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.275000e+03   # n1
    1000024   1.275325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.275000e+03   # n1
    1000024   1.275183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1275_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.275000e+03   # n1
    1000024   1.275236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.300000e+03   # n1
    1000024   1.300325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.300000e+03   # n1
    1000024   1.300183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1300_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.300000e+03   # n1
    1000024   1.300236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.315000e+03   # n1
    1000024   1.315325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.315000e+03   # n1
    1000024   1.315183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1315_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.315000e+03   # n1
    1000024   1.315236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.325000e+03   # n1
    1000024   1.325325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.325000e+03   # n1
    1000024   1.325183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1325_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.325000e+03   # n1
    1000024   1.325236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.350000e+03   # n1
    1000024   1.350325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.350000e+03   # n1
    1000024   1.350183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1350_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.350000e+03   # n1
    1000024   1.350236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.365000e+03   # n1
    1000024   1.365325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.365000e+03   # n1
    1000024   1.365183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1365_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.365000e+03   # n1
    1000024   1.365236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.375000e+03   # n1
    1000024   1.375325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.375000e+03   # n1
    1000024   1.375183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1375_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.375000e+03   # n1
    1000024   1.375236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.400000e+03   # n1
    1000024   1.400325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.400000e+03   # n1
    1000024   1.400183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1400_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.400000e+03   # n1
    1000024   1.400236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.415000e+03   # n1
    1000024   1.415325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.415000e+03   # n1
    1000024   1.415183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1415_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.415000e+03   # n1
    1000024   1.415236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.425000e+03   # n1
    1000024   1.425325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.425000e+03   # n1
    1000024   1.425183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1425_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.425000e+03   # n1
    1000024   1.425236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.450000e+03   # n1
    1000024   1.450325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.450000e+03   # n1
    1000024   1.450183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1450_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.450000e+03   # n1
    1000024   1.450236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.465000e+03   # n1
    1000024   1.465325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.465000e+03   # n1
    1000024   1.465183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1465_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.465000e+03   # n1
    1000024   1.465236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.475000e+03   # n1
    1000024   1.475325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.475000e+03   # n1
    1000024   1.475183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1475_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.475000e+03   # n1
    1000024   1.475236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+03   # n1
    1000024   1.500325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+03   # n1
    1000024   1.500183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1500_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+03   # n1
    1000024   1.500236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+02   # n1
    1000024   1.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+02   # n1
    1000024   1.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-150_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.500000e+02   # n1
    1000024   1.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.515000e+03   # n1
    1000024   1.515325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.515000e+03   # n1
    1000024   1.515183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1515_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.515000e+03   # n1
    1000024   1.515236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.525000e+03   # n1
    1000024   1.525325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.525000e+03   # n1
    1000024   1.525183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1525_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.525000e+03   # n1
    1000024   1.525236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.550000e+03   # n1
    1000024   1.550325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.550000e+03   # n1
    1000024   1.550183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1550_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.550000e+03   # n1
    1000024   1.550236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.565000e+03   # n1
    1000024   1.565325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.565000e+03   # n1
    1000024   1.565183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1565_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.565000e+03   # n1
    1000024   1.565236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.575000e+03   # n1
    1000024   1.575325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.575000e+03   # n1
    1000024   1.575183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1575_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.575000e+03   # n1
    1000024   1.575236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.600000e+03   # n1
    1000024   1.600325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.600000e+03   # n1
    1000024   1.600183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1600_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.600000e+03   # n1
    1000024   1.600236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.615000e+03   # n1
    1000024   1.615325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.615000e+03   # n1
    1000024   1.615183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1615_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.615000e+03   # n1
    1000024   1.615236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.625000e+03   # n1
    1000024   1.625325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.625000e+03   # n1
    1000024   1.625183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1625_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.625000e+03   # n1
    1000024   1.625236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.650000e+03   # n1
    1000024   1.650325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.650000e+03   # n1
    1000024   1.650183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1650_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.650000e+03   # n1
    1000024   1.650236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.665000e+03   # n1
    1000024   1.665325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.665000e+03   # n1
    1000024   1.665183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1665_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.665000e+03   # n1
    1000024   1.665236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.675000e+03   # n1
    1000024   1.675325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.675000e+03   # n1
    1000024   1.675183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1675_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.675000e+03   # n1
    1000024   1.675236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.700000e+03   # n1
    1000024   1.700325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.700000e+03   # n1
    1000024   1.700183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1700_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.700000e+03   # n1
    1000024   1.700236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.715000e+03   # n1
    1000024   1.715325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.715000e+03   # n1
    1000024   1.715183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1715_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.715000e+03   # n1
    1000024   1.715236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.725000e+03   # n1
    1000024   1.725325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.725000e+03   # n1
    1000024   1.725183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1725_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.725000e+03   # n1
    1000024   1.725236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+03   # n1
    1000024   1.750325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+03   # n1
    1000024   1.750183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1750_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+03   # n1
    1000024   1.750236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+02   # n1
    1000024   1.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+02   # n1
    1000024   1.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-175_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.750000e+02   # n1
    1000024   1.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.765000e+03   # n1
    1000024   1.765325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.765000e+03   # n1
    1000024   1.765183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1765_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.765000e+03   # n1
    1000024   1.765236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.775000e+03   # n1
    1000024   1.775325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.775000e+03   # n1
    1000024   1.775183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1775_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.775000e+03   # n1
    1000024   1.775236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.800000e+03   # n1
    1000024   1.800325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.800000e+03   # n1
    1000024   1.800183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1800_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.800000e+03   # n1
    1000024   1.800236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.815000e+03   # n1
    1000024   1.815325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.815000e+03   # n1
    1000024   1.815183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1815_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.815000e+03   # n1
    1000024   1.815236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.825000e+03   # n1
    1000024   1.825325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.825000e+03   # n1
    1000024   1.825183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1825_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.825000e+03   # n1
    1000024   1.825236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.850000e+03   # n1
    1000024   1.850325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.850000e+03   # n1
    1000024   1.850183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1850_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.850000e+03   # n1
    1000024   1.850236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.865000e+03   # n1
    1000024   1.865325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.865000e+03   # n1
    1000024   1.865183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1865_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.865000e+03   # n1
    1000024   1.865236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.875000e+03   # n1
    1000024   1.875325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.875000e+03   # n1
    1000024   1.875183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1875_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.875000e+03   # n1
    1000024   1.875236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.900000e+03   # n1
    1000024   1.900325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.900000e+03   # n1
    1000024   1.900183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1900_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.900000e+03   # n1
    1000024   1.900236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.915000e+03   # n1
    1000024   1.915325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.915000e+03   # n1
    1000024   1.915183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1915_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.915000e+03   # n1
    1000024   1.915236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.925000e+03   # n1
    1000024   1.925325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.925000e+03   # n1
    1000024   1.925183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1925_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.925000e+03   # n1
    1000024   1.925236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.950000e+03   # n1
    1000024   1.950325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.950000e+03   # n1
    1000024   1.950183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1950_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.950000e+03   # n1
    1000024   1.950236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.965000e+03   # n1
    1000024   1.965325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.965000e+03   # n1
    1000024   1.965183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1965_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.965000e+03   # n1
    1000024   1.965236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.975000e+03   # n1
    1000024   1.975325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.975000e+03   # n1
    1000024   1.975183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1975_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.975000e+03   # n1
    1000024   1.975236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+00   # n1
    1000024   1.324858e+00   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+00   # n1
    1000024   1.182884e+00   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-1_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   1.000000e+00   # n1
    1000024   1.236389e+00   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+03   # n1
    1000024   2.000325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+03   # n1
    1000024   2.000183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2000_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+03   # n1
    1000024   2.000236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+02   # n1
    1000024   2.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+02   # n1
    1000024   2.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-200_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.000000e+02   # n1
    1000024   2.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.025000e+03   # n1
    1000024   2.025325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.025000e+03   # n1
    1000024   2.025183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2025_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.025000e+03   # n1
    1000024   2.025236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.050000e+03   # n1
    1000024   2.050325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.050000e+03   # n1
    1000024   2.050183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2050_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.050000e+03   # n1
    1000024   2.050236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.075000e+03   # n1
    1000024   2.075325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.075000e+03   # n1
    1000024   2.075183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2075_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.075000e+03   # n1
    1000024   2.075236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.100000e+03   # n1
    1000024   2.100325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.100000e+03   # n1
    1000024   2.100183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2100_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.100000e+03   # n1
    1000024   2.100236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.125000e+03   # n1
    1000024   2.125325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.125000e+03   # n1
    1000024   2.125183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2125_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.125000e+03   # n1
    1000024   2.125236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.150000e+03   # n1
    1000024   2.150325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.150000e+03   # n1
    1000024   2.150183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2150_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.150000e+03   # n1
    1000024   2.150236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.175000e+03   # n1
    1000024   2.175325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.175000e+03   # n1
    1000024   2.175183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2175_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.175000e+03   # n1
    1000024   2.175236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.200000e+03   # n1
    1000024   2.200325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.200000e+03   # n1
    1000024   2.200183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2200_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.200000e+03   # n1
    1000024   2.200236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.225000e+03   # n1
    1000024   2.225325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.225000e+03   # n1
    1000024   2.225183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2225_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.225000e+03   # n1
    1000024   2.225236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+03   # n1
    1000024   2.250325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+03   # n1
    1000024   2.250183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2250_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+03   # n1
    1000024   2.250236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+02   # n1
    1000024   2.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+02   # n1
    1000024   2.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-225_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.250000e+02   # n1
    1000024   2.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.275000e+03   # n1
    1000024   2.275325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.275000e+03   # n1
    1000024   2.275183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2275_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.275000e+03   # n1
    1000024   2.275236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.300000e+03   # n1
    1000024   2.300325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.300000e+03   # n1
    1000024   2.300183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2300_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.300000e+03   # n1
    1000024   2.300236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.325000e+03   # n1
    1000024   2.325325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.325000e+03   # n1
    1000024   2.325183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2325_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.325000e+03   # n1
    1000024   2.325236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.350000e+03   # n1
    1000024   2.350325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.350000e+03   # n1
    1000024   2.350183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2350_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.350000e+03   # n1
    1000024   2.350236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.375000e+03   # n1
    1000024   2.375325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.375000e+03   # n1
    1000024   2.375183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2375_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.375000e+03   # n1
    1000024   2.375236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.400000e+03   # n1
    1000024   2.400325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.400000e+03   # n1
    1000024   2.400183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2400_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.400000e+03   # n1
    1000024   2.400236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.425000e+03   # n1
    1000024   2.425325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.425000e+03   # n1
    1000024   2.425183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2425_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.425000e+03   # n1
    1000024   2.425236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.450000e+03   # n1
    1000024   2.450325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.450000e+03   # n1
    1000024   2.450183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2450_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.450000e+03   # n1
    1000024   2.450236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.475000e+03   # n1
    1000024   2.475325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.475000e+03   # n1
    1000024   2.475183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2475_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.475000e+03   # n1
    1000024   2.475236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+03   # n1
    1000024   2.500325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+03   # n1
    1000024   2.500183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2500_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+03   # n1
    1000024   2.500236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+02   # n1
    1000024   2.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+02   # n1
    1000024   2.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-250_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+02   # n1
    1000024   2.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.525000e+03   # n1
    1000024   2.525325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.525000e+03   # n1
    1000024   2.525183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2525_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.525000e+03   # n1
    1000024   2.525236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.550000e+03   # n1
    1000024   2.550325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.550000e+03   # n1
    1000024   2.550183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2550_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.550000e+03   # n1
    1000024   2.550236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.575000e+03   # n1
    1000024   2.575325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.575000e+03   # n1
    1000024   2.575183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2575_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.575000e+03   # n1
    1000024   2.575236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+01   # n1
    1000024   2.532486e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+01   # n1
    1000024   2.518288e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-25_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.500000e+01   # n1
    1000024   2.523639e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.600000e+03   # n1
    1000024   2.600325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.600000e+03   # n1
    1000024   2.600183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2600_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.600000e+03   # n1
    1000024   2.600236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.625000e+03   # n1
    1000024   2.625325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.625000e+03   # n1
    1000024   2.625183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2625_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.625000e+03   # n1
    1000024   2.625236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.650000e+03   # n1
    1000024   2.650325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.650000e+03   # n1
    1000024   2.650183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2650_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.650000e+03   # n1
    1000024   2.650236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.675000e+03   # n1
    1000024   2.675325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.675000e+03   # n1
    1000024   2.675183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2675_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.675000e+03   # n1
    1000024   2.675236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.700000e+03   # n1
    1000024   2.700325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.700000e+03   # n1
    1000024   2.700183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2700_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.700000e+03   # n1
    1000024   2.700236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.725000e+03   # n1
    1000024   2.725325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.725000e+03   # n1
    1000024   2.725183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2725_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.725000e+03   # n1
    1000024   2.725236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+03   # n1
    1000024   2.750325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+03   # n1
    1000024   2.750183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2750_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+03   # n1
    1000024   2.750236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+02   # n1
    1000024   2.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+02   # n1
    1000024   2.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-275_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.750000e+02   # n1
    1000024   2.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.775000e+03   # n1
    1000024   2.775325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.775000e+03   # n1
    1000024   2.775183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2775_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.775000e+03   # n1
    1000024   2.775236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.800000e+03   # n1
    1000024   2.800325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.800000e+03   # n1
    1000024   2.800183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2800_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.800000e+03   # n1
    1000024   2.800236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.825000e+03   # n1
    1000024   2.825325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.825000e+03   # n1
    1000024   2.825183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2825_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.825000e+03   # n1
    1000024   2.825236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.850000e+03   # n1
    1000024   2.850325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.850000e+03   # n1
    1000024   2.850183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2850_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.850000e+03   # n1
    1000024   2.850236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.875000e+03   # n1
    1000024   2.875325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.875000e+03   # n1
    1000024   2.875183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2875_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.875000e+03   # n1
    1000024   2.875236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.900000e+03   # n1
    1000024   2.900325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.900000e+03   # n1
    1000024   2.900183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2900_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.900000e+03   # n1
    1000024   2.900236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.925000e+03   # n1
    1000024   2.925325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.925000e+03   # n1
    1000024   2.925183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2925_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.925000e+03   # n1
    1000024   2.925236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.950000e+03   # n1
    1000024   2.950325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.950000e+03   # n1
    1000024   2.950183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2950_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.950000e+03   # n1
    1000024   2.950236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.975000e+03   # n1
    1000024   2.975325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.975000e+03   # n1
    1000024   2.975183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-2975_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   2.975000e+03   # n1
    1000024   2.975236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+03   # n1
    1000024   3.000325e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+03   # n1
    1000024   3.000183e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-3000_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+03   # n1
    1000024   3.000236e+03   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+02   # n1
    1000024   3.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+02   # n1
    1000024   3.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-300_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.000000e+02   # n1
    1000024   3.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.150000e+02   # n1
    1000024   3.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.150000e+02   # n1
    1000024   3.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-315_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.150000e+02   # n1
    1000024   3.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.250000e+02   # n1
    1000024   3.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.250000e+02   # n1
    1000024   3.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-325_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.250000e+02   # n1
    1000024   3.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.500000e+02   # n1
    1000024   3.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.500000e+02   # n1
    1000024   3.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-350_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.500000e+02   # n1
    1000024   3.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.650000e+02   # n1
    1000024   3.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.650000e+02   # n1
    1000024   3.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-365_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.650000e+02   # n1
    1000024   3.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.750000e+02   # n1
    1000024   3.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.750000e+02   # n1
    1000024   3.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-375_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   3.750000e+02   # n1
    1000024   3.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.000000e+02   # n1
    1000024   4.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.000000e+02   # n1
    1000024   4.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-400_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.000000e+02   # n1
    1000024   4.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.150000e+02   # n1
    1000024   4.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.150000e+02   # n1
    1000024   4.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-415_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.150000e+02   # n1
    1000024   4.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.250000e+02   # n1
    1000024   4.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.250000e+02   # n1
    1000024   4.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-425_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.250000e+02   # n1
    1000024   4.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.500000e+02   # n1
    1000024   4.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.500000e+02   # n1
    1000024   4.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-450_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.500000e+02   # n1
    1000024   4.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.650000e+02   # n1
    1000024   4.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.650000e+02   # n1
    1000024   4.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-465_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.650000e+02   # n1
    1000024   4.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.750000e+02   # n1
    1000024   4.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.750000e+02   # n1
    1000024   4.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-475_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   4.750000e+02   # n1
    1000024   4.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+02   # n1
    1000024   5.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+02   # n1
    1000024   5.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-500_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+02   # n1
    1000024   5.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+01   # n1
    1000024   5.032486e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+01   # n1
    1000024   5.018288e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-50_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.000000e+01   # n1
    1000024   5.023639e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.150000e+02   # n1
    1000024   5.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.150000e+02   # n1
    1000024   5.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-515_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.150000e+02   # n1
    1000024   5.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.250000e+02   # n1
    1000024   5.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.250000e+02   # n1
    1000024   5.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-525_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.250000e+02   # n1
    1000024   5.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.500000e+02   # n1
    1000024   5.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.500000e+02   # n1
    1000024   5.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-550_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.500000e+02   # n1
    1000024   5.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.650000e+02   # n1
    1000024   5.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.650000e+02   # n1
    1000024   5.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-565_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.650000e+02   # n1
    1000024   5.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.750000e+02   # n1
    1000024   5.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.750000e+02   # n1
    1000024   5.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-575_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   5.750000e+02   # n1
    1000024   5.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.000000e+02   # n1
    1000024   6.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.000000e+02   # n1
    1000024   6.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-600_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.000000e+02   # n1
    1000024   6.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.150000e+02   # n1
    1000024   6.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.150000e+02   # n1
    1000024   6.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-615_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.150000e+02   # n1
    1000024   6.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.250000e+02   # n1
    1000024   6.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.250000e+02   # n1
    1000024   6.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-625_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.250000e+02   # n1
    1000024   6.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.500000e+02   # n1
    1000024   6.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.500000e+02   # n1
    1000024   6.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-650_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.500000e+02   # n1
    1000024   6.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.650000e+02   # n1
    1000024   6.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.650000e+02   # n1
    1000024   6.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-665_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.650000e+02   # n1
    1000024   6.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.750000e+02   # n1
    1000024   6.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.750000e+02   # n1
    1000024   6.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-675_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   6.750000e+02   # n1
    1000024   6.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.000000e+02   # n1
    1000024   7.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.000000e+02   # n1
    1000024   7.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-700_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.000000e+02   # n1
    1000024   7.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.150000e+02   # n1
    1000024   7.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.150000e+02   # n1
    1000024   7.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-715_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.150000e+02   # n1
    1000024   7.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.250000e+02   # n1
    1000024   7.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.250000e+02   # n1
    1000024   7.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-725_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.250000e+02   # n1
    1000024   7.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+02   # n1
    1000024   7.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+02   # n1
    1000024   7.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-750_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+02   # n1
    1000024   7.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+01   # n1
    1000024   7.532486e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+01   # n1
    1000024   7.518288e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-75_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.500000e+01   # n1
    1000024   7.523639e+01   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.650000e+02   # n1
    1000024   7.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.650000e+02   # n1
    1000024   7.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-765_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.650000e+02   # n1
    1000024   7.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.750000e+02   # n1
    1000024   7.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.750000e+02   # n1
    1000024   7.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-775_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   7.750000e+02   # n1
    1000024   7.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.000000e+02   # n1
    1000024   8.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.000000e+02   # n1
    1000024   8.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-800_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.000000e+02   # n1
    1000024   8.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.150000e+02   # n1
    1000024   8.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.150000e+02   # n1
    1000024   8.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-815_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.150000e+02   # n1
    1000024   8.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.250000e+02   # n1
    1000024   8.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.250000e+02   # n1
    1000024   8.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-825_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.250000e+02   # n1
    1000024   8.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.500000e+02   # n1
    1000024   8.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.500000e+02   # n1
    1000024   8.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-850_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.500000e+02   # n1
    1000024   8.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.650000e+02   # n1
    1000024   8.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.650000e+02   # n1
    1000024   8.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-865_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.650000e+02   # n1
    1000024   8.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.750000e+02   # n1
    1000024   8.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.750000e+02   # n1
    1000024   8.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-875_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   8.750000e+02   # n1
    1000024   8.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.000000e+02   # n1
    1000024   9.003249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.000000e+02   # n1
    1000024   9.001829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-900_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.000000e+02   # n1
    1000024   9.002364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.150000e+02   # n1
    1000024   9.153249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.150000e+02   # n1
    1000024   9.151829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-915_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.150000e+02   # n1
    1000024   9.152364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.250000e+02   # n1
    1000024   9.253249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.250000e+02   # n1
    1000024   9.251829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-925_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.250000e+02   # n1
    1000024   9.252364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.500000e+02   # n1
    1000024   9.503249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.500000e+02   # n1
    1000024   9.501829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-950_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.500000e+02   # n1
    1000024   9.502364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.650000e+02   # n1
    1000024   9.653249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.650000e+02   # n1
    1000024   9.651829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-965_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.650000e+02   # n1
    1000024   9.652364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-10cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-10cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.750000e+02   # n1
    1000024   9.753249e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  1.973271e-15 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-200cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-200cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.750000e+02   # n1
    1000024   9.751829e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  9.866601e-17 # x1+ decays
 #          BR          NDA       ID1     ID2

--- a/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-50cm.txt
+++ b/SUSY/LLTChipm/pointcharginodecay_mLSP-975_ctau-50cm.txt
@@ -3,6 +3,7 @@ BLOCK MASS
 #  PDG code   mass   particle
    1000022   9.750000e+02   # n1
    1000024   9.752364e+02   # x1+
+Block
 # DECAY TABLE
 DECAY   1000024  3.946640e-16 # x1+ decays
 #          BR          NDA       ID1     ID2


### PR DESCRIPTION
it was found that an extra line was needed to prevent the chargino to reach the detector even after its decay.