### PR TITLE
Fix charge info in 1200,1600,2000 GeV HIP files

### DIFF
--- a/particles_HIP3_stau_1200_GeV.txt
+++ b/particles_HIP3_stau_1200_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    1200.0  #  ~HIP2
-       -17    1200.0  #  ~HIPbar2
+        17    1200.0  #  ~HIP3
+       -17    1200.0  #  ~HIPbar3
 Block       
 
 

--- a/particles_HIP3_stau_1600_GeV.txt
+++ b/particles_HIP3_stau_1600_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    1600.0  #  ~HIP2
-       -17    1600.0  #  ~HIPbar2
+        17    1600.0  #  ~HIP3
+       -17    1600.0  #  ~HIPbar3
 Block       
 
 

--- a/particles_HIP3_stau_2000_GeV.txt
+++ b/particles_HIP3_stau_2000_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    2000.0  #  ~HIP2
-       -17    2000.0  #  ~HIPbar2
+        17    2000.0  #  ~HIP3
+       -17    2000.0  #  ~HIPbar3
 Block       
 
 

--- a/particles_HIP6_stau_1200_GeV.txt
+++ b/particles_HIP6_stau_1200_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    1200.0  #  ~HIP2
-       -17    1200.0  #  ~HIPbar2
+        17    1200.0  #  ~HIP6
+       -17    1200.0  #  ~HIPbar6
 Block       
 
 

--- a/particles_HIP6_stau_1600_GeV.txt
+++ b/particles_HIP6_stau_1600_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    1600.0  #  ~HIP2
-       -17    1600.0  #  ~HIPbar2
+        17    1600.0  #  ~HIP6
+       -17    1600.0  #  ~HIPbar6
 Block       
 
 

--- a/particles_HIP6_stau_2000_GeV.txt
+++ b/particles_HIP6_stau_2000_GeV.txt
@@ -1,7 +1,7 @@
 Block MASS   #
 #  PDG code   mass                 particle
-        17    2000.0  #  ~HIP2
-       -17    2000.0  #  ~HIPbar2
+        17    2000.0  #  ~HIP6
+       -17    2000.0  #  ~HIPbar6
 Block       
 
 


### PR DESCRIPTION
I found a typo in the charge determination, HIP3 has not 3 charge and HIP6 has now 6 charge.

Please note these are changes in the comments, so it was not very obvious that those are relevant... After local tests it seems they are!