### PR TITLE
Add new mass/ctau points for long lived staus 

### DIFF
--- a/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-100_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-125_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-150_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-175_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    1.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-200_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p01mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p01mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-11 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p05mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p05mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-0p5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-10mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-10mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-225_mLSP-1_ctau-5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.250000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-250_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p01mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p01mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-11 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p05mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p05mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-0p5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-10mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-10mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-275_mLSP-1_ctau-5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    2.750000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-300_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-350_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    3.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-400_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-450_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    4.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-500_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p01mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p01mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-11 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p05mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p05mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-0p5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-10mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-10mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-550_mLSP-1_ctau-5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    5.500000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p01mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p01mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-11 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p05mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p05mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-12 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-0p5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-10mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-10mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-1mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-1mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-13 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-5mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-600_mLSP-1_ctau-5mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    6.000000e+02  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-14 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-10000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-10000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    9.000000e+01  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-17 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-1000mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-1000mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    9.000000e+01  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-16 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-100mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-100mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    9.000000e+01  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  1.973270e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15

--- a/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-50mm.txt
+++ b/SUSY/LongLivedStau/LongLivedStau_mStau-90_mLSP-1_ctau-50mm.txt
@@ -1,0 +1,10 @@
+
+BLOCK MASS
+#  PDG code   mass   particle
+   1000015    9.000000e+01  # ~tau_1
+   1000022    1.000000e+00  # ~chi_10
+Block
+# DECAY TABLE
+DECAY    1000015  3.946540e-15 # tau + ~chi_10
+#          BR          NDA       ID1     ID2
+           1.0         2          1000022    15


### PR DESCRIPTION
These mass/ctau points were missing, they are needed for the central production of long lived stau samples.
These samples will be produced for the SUS displaced taus analysis on Run2 data (UL campaigns), and in the near future Run3 samples will also be generated. 