### PR TITLE
Long-lived stop with 2-body and 4-body decays

### DIFF
--- a/SUSY/LLStop/LL_stop_1000_Neutralino_975_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_975_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_980_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_980_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_980_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_980_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_985_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_985_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_985_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_985_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_988_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_988_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1000_Neutralino_988_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1000_Neutralino_988_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.000000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     9.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1075_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1075_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.075000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1080_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1080_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.080000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1080_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1080_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.080000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1085_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1085_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.085000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1085_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1085_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.085000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1088_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1088_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.088000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1100_Neutralino_1088_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1100_Neutralino_1088_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.100000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.088000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1175_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1175_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.175000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1180_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1180_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.180000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1180_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1180_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.180000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1185_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1185_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.185000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1185_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1185_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.185000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1188_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1188_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.188000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1200_Neutralino_1188_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1200_Neutralino_1188_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.200000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.188000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1275_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1275_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.275000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1280_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1280_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.280000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1280_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1280_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.280000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1285_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1285_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.285000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1285_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1285_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.285000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1288_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1288_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.288000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1300_Neutralino_1288_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1300_Neutralino_1288_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.300000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.288000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1375_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1375_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.375000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1380_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1380_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.380000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1380_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1380_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.380000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1385_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1385_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.385000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1385_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1385_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.385000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1388_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1388_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.388000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_1400_Neutralino_1388_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_1400_Neutralino_1388_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     1.400000e+03          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     1.388000e+03           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_375_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_375_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_380_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_380_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_380_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_380_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_385_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_385_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_385_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_385_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_388_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_388_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_400_Neutralino_388_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_400_Neutralino_388_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     4.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     3.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_475_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_475_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_480_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_480_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_480_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_480_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_485_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_485_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_485_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_485_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_488_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_488_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_500_Neutralino_488_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_500_Neutralino_488_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     5.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     4.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_575_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_575_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_580_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_580_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_580_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_580_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_585_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_585_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_585_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_585_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_588_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_588_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_600_Neutralino_588_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_600_Neutralino_588_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     6.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     5.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_675_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_675_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_680_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_680_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_680_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_680_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_685_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_685_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_685_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_685_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_688_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_688_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_700_Neutralino_688_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_700_Neutralino_688_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     7.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     6.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_775_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_775_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_780_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_780_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_780_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_780_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_785_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_785_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_785_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_785_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_788_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_788_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_800_Neutralino_788_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_800_Neutralino_788_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     8.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     7.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_875_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_875_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.750000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_880_CTau_0p2_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_880_CTau_0p2_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-13   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_880_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_880_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.800000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_885_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_885_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_885_CTau_2p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_885_CTau_2p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.850000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-14   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_888_CTau_200p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_888_CTau_200p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-16   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays

--- a/SUSY/LLStop/LL_stop_900_Neutralino_888_CTau_20p0_SLHA.spc
+++ b/SUSY/LLStop/LL_stop_900_Neutralino_888_CTau_20p0_SLHA.spc
@@ -1,0 +1,65 @@
+
+BLOCK MASS  # Mass Spectrum
+# PDG code           mass       particle
+   1000001     1.00000000E+05   # ~d_L
+   2000001     1.00000000E+05   # ~d_R
+   1000002     1.00000000E+05   # ~u_L
+   2000002     1.00000000E+05   # ~u_R
+   1000003     1.00000000E+05   # ~s_L
+   2000003     1.00000000E+05   # ~s_R
+   1000004     1.00000000E+05   # ~c_L
+   2000004     1.00000000E+05   # ~c_R
+   1000005     1.00000000E+05   # ~b_1
+   2000005     1.00000000E+05   # ~b_2
+   1000006     9.000000e+02          # ~t_1
+   2000006     1.00000000E+05   # ~t_2
+   1000011     1.00000000E+05   # ~e_L
+   2000011     1.00000000E+05   # ~e_R
+   1000012     1.00000000E+05   # ~nu_eL
+   1000013     1.00000000E+05   # ~mu_L
+   2000013     1.00000000E+05   # ~mu_R
+   1000014     1.00000000E+05   # ~nu_muL
+   1000015     1.00000000E+05   # ~tau_1
+   2000015     1.00000000E+05   # ~tau_2
+   1000016     1.00000000E+05   # ~nu_tauL
+   1000021     1.00000000E+05    # ~g
+   1000022     8.880000e+02           # ~chi_10
+   1000023     1.00000000E+05   # ~chi_20
+   1000025     1.00000000E+05   # ~chi_30
+   1000035     1.00000000E+05   # ~chi_40
+   1000024     1.00000000E+05   # ~chi_1+
+   1000037     1.00000000E+05   # ~chi_2+
+
+# DECAY TABLE
+#         PDG            Width
+DECAY   1000001     0.00000000E+00   # sdown_L decays
+DECAY   2000001     0.00000000E+00   # sdown_R decays
+DECAY   1000002     0.00000000E+00   # sup_L decays
+DECAY   2000002     0.00000000E+00   # sup_R decays
+DECAY   1000003     0.00000000E+00   # sstrange_L decays
+DECAY   2000003     0.00000000E+00   # sstrange_R decays
+DECAY   1000004     0.00000000E+00   # scharm_L decays
+DECAY   2000004     0.00000000E+00   # scharm_R decays
+DECAY   1000005     0.00000000E+00   # sbottom1 decays
+DECAY   2000005     0.00000000E+00   # sbottom2 decays
+DECAY   1000006     9.866349e-15   # stop1 decays
+    0.00000000E+00    4    1000022      5     -1    2  # dummy allowed decay, in order to turn on off-shell decays
+    0.50000000E+00    3    1000022      5   24
+    0.50000000E+00    2    1000022      4 
+DECAY   2000006     0.00000000E+00   # stop2 decays
+DECAY   1000011     0.00000000E+00   # selectron_L decays
+DECAY   2000011     0.00000000E+00   # selectron_R decays
+DECAY   1000012     0.00000000E+00   # snu_elL decays
+DECAY   1000013     0.00000000E+00   # smuon_L decays
+DECAY   2000013     0.00000000E+00   # smuon_R decays
+DECAY   1000014     0.00000000E+00   # snu_muL decays
+DECAY   1000015     0.00000000E+00   # stau_1 decays
+DECAY   2000015     0.00000000E+00   # stau_2 decays
+DECAY   1000016     0.00000000E+00   # snu_tauL decays
+DECAY   1000021     0.00000000E+00   # gluino decays
+DECAY   1000022     0.00000000E+00   # neutralino1 decays
+DECAY   1000023     0.00000000E+00   # neutralino2 decays
+DECAY   1000024     0.00000000E+00   # chargino1+ decays
+DECAY   1000025     0.00000000E+00   # neutralino3 decays
+DECAY   1000035     0.00000000E+00   # neutralino4 decays
+DECAY   1000037     0.00000000E+00   # chargino2+ decays


### PR DESCRIPTION
SLHA files for long-lived stop with 2-body and 4-body decays. The branching ratio is 50% for each decay channels.
2-body: stop -> c + neutrlino
4-body: stop -> b + W + neutralino, W decays to a pair of fermions